### PR TITLE
Add audience parameter to lock, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,36 +74,36 @@ Make a new file called Auth0.plist, add this into it, clearly replacing the temp
 
 ### Android
 
-Add this to your AndroidManifest.xml
+1. Add `manifestPlaceholders` to `app/App_resources/Android/app.gradle`.
+
+```
+
+defaultConfig {  
+    generatedDensities = []
+    applicationId = "org.nativescript.app"  
+    manifestPlaceholders = [auth0Domain: "yourdomain.auth0.com", auth0Scheme: "https"]
+  } 
+```
+
+2. Add this to your `AndroidManifest.xml`
 
 ``` xml
-<!--Auth0 Lock-->
-      <activity
-          android:name="com.auth0.android.lock.LockActivity"
-          android:label="Classic Lock"
-          android:launchMode="singleTask"
-          android:screenOrientation="portrait"
-          android:theme="@style/Lock.Theme">
-          <intent-filter>
-              <action android:name="android.intent.action.VIEW" />
-
-              <category android:name="android.intent.category.DEFAULT" />
-              <category android:name="android.intent.category.BROWSABLE" />
-
-              <data
-                  android:host="nativescript.auth0.com"
-                  android:pathPrefix="/android/__PACKAGE__/callback"
-                  android:scheme="https" />
-          </intent-filter>
-      </activity>
-      <!--Auth0 Lock End-->
-
-  <!--Auth0 Lock Embedded WebView-->
-      <activity
-          android:name="com.auth0.android.provider.WebAuthActivity" />
-      <!--Auth0 Lock Embedded WebView End-->
+    <activity
+			android:name="com.auth0.android.lock.LockActivity"
+			android:label="@string/app_name"
+			android:launchMode="singleTask"
+			android:screenOrientation="portrait"
+			android:theme="@style/MyLock.Theme"/>
 ```
 [Sample from demo](https://github.com/sitefinitysteve/nativescript-auth0/blob/master/demo/app/App_Resources/Android/AndroidManifest.xml#L39-L63)
+
+
+3. Add this to `app/App_resouces/Android/values/styles.xml`
+
+``` xml
+<style name="MyLock.Theme" parent="Lock.Theme" />
+```
+
 
 ## Usage
 
@@ -118,7 +118,8 @@ Create your lock object, I like to do this in a [shared helper or something](htt
   var lock = new Auth0Lock({
         clientId: '<your clientid>',
         domain:'<your domain>',
-        scopes: [ "offline_access openid"] //Optional param, check the auth0 docs
+        audience: '<your-auth0-audience>',
+        scope: [ 'offline_access', 'openid'] //Optional param, check the auth0 docs
     });
 ```
 

--- a/auth0.android.ts
+++ b/auth0.android.ts
@@ -28,7 +28,11 @@ export class Auth0Lock extends common.Auth0Lock{
                 var auth0 = new com.auth0.android.Auth0(this.options.clientId, this.options.domain);
                 auth0.setOIDCConformant(true);
 
-                var builder = com.auth0.android.lock.Lock.newBuilder(auth0, this._callback); 
+                var builder = com.auth0.android.lock.Lock.newBuilder(auth0, this._callback);
+
+                if (this.options.audience) {
+                    builder.withAudience(this.options.audience);
+                }
                 
                 var activity = frameModule.topmost().android.activity;
                 

--- a/auth0.common.d.ts
+++ b/auth0.common.d.ts
@@ -1,6 +1,7 @@
 export interface Options {
     domain: string;
     clientId: string;
+    audience: string;
     scope?: Array<string>;
 }
 export interface Credentials {

--- a/auth0.common.ts
+++ b/auth0.common.ts
@@ -6,6 +6,7 @@ var jwt = require("./jwt");
 export interface Options{
   domain: string,
   clientId: string,
+  audience: string,
   scope?: Array<string>
 }
 

--- a/auth0.ios.ts
+++ b/auth0.ios.ts
@@ -20,14 +20,23 @@ export class Auth0Lock extends common.Auth0Lock{
             var page = frameModule.topmost().ios.controller;
 
             let lock: Lock = Lock.classic();
-
+            
             //Add scope
             if(this.options.scope){
                 var scopeItems = this.options.scope.join(" ");
                 console.log("Adding scope of " + scopeItems);
 
+                lock.withOptions {
+                    $0.oidcConformant = true
+                    $0.scope = scopeItems
+                }
+
                 //Pending update from telerik\progress
                 //lockClassicScreen.authenticationParameters.scopes = this.options.scope;
+            } else {
+                lock.withOptions {
+                    $0.oidcConformant = true
+                }
             }
 
             lock.onAuthWithCallback((credientials: A0Credentials) => {

--- a/demo/app/App_Resources/Android/app.gradle
+++ b/demo/app/App_Resources/Android/app.gradle
@@ -9,6 +9,7 @@ android {
   defaultConfig {  
     generatedDensities = []
     applicationId = "org.nativescript.auth0demo"  
+    manifestPlaceholders = [auth0Domain: "yourdomain.auth0.com", auth0Scheme: "https"]
   }  
   aaptOptions {  
     additionalParameters "--no-version-vectors"  


### PR DESCRIPTION
- Added `audience` parameter to options object.
- Updated README file to use setup steps from latest Auth0 docs