### PR TITLE
check for null android foregroundActivity on start

### DIFF
--- a/src/auth0.android.ts
+++ b/src/auth0.android.ts
@@ -64,7 +64,7 @@ export class Auth0 extends Auth0Common {
 
         return new Promise((resolve, reject) => {
             try {
-                const activity = application.android.foregroundActivity === null ? application.android.startActivity : application.android.foregroundActivity;
+                const activity = application.android.foregroundActivity == null ? application.android.startActivity : application.android.foregroundActivity;
                 webAuth.start(activity, {
                     onFailure: (dialogOrException: android.app.Dialog | AuthenticationException) => {
                         if (dialogOrException instanceof android.app.Dialog) {

--- a/src/auth0.android.ts
+++ b/src/auth0.android.ts
@@ -64,7 +64,8 @@ export class Auth0 extends Auth0Common {
 
         return new Promise((resolve, reject) => {
             try {
-                webAuth.start(application.android.foregroundActivity, {
+                const activity = application.android.foregroundActivity === null ? application.android.startActivity : application.android.foregroundActivity;
+                webAuth.start(activity, {
                     onFailure: (dialogOrException: android.app.Dialog | AuthenticationException) => {
                         if (dialogOrException instanceof android.app.Dialog) {
                             reject(new WebAuthException(dialogOrException.toString()));


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- UNUSED FOR NOW
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included
-->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Android foregroundActivity may be null in certain cases in NS-Vue at WebAuthentication start.  
## What is the new behavior?
<!-- Describe the changes. -->
Put in a conditional check for foregroundActivity being null and if so, use startActivity instead.

Fixes #52 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

