### PR TITLE
feat(ios): add logout function using the reset session

### DIFF
--- a/src/android/provider/webAuthProvider.d.ts
+++ b/src/android/provider/webAuthProvider.d.ts
@@ -38,4 +38,5 @@ export declare class WebAuthProvider {
     start(activity: Activity, callback: AuthCallback): void;
     static resume(intent: Intent): boolean;
     static getInstance(): OAuthManager;
+    clearSession(federated: boolean, callback: (success: boolean) => void): void;
 }

--- a/src/android/provider/webAuthProvider.ts
+++ b/src/android/provider/webAuthProvider.ts
@@ -266,4 +266,8 @@ export class WebAuthProvider {
     public static getInstance(): OAuthManager {
         return WebAuthProvider.managerInstance;
     }
+
+    public clearSession(federated: boolean, callback: (success: boolean) => void) {
+        callback(true);
+    }
 }

--- a/src/auth0-common.ts
+++ b/src/auth0-common.ts
@@ -36,4 +36,5 @@ export abstract class Auth0Common {
     public abstract renewCredentials(refreshToken: string): Promise<Credentials>;
     public abstract revokeRefreshToken(refreshToken: string): Promise<void>;
     public abstract getUserInfo(accessToken: string): Promise<UserInfo>;
+    public abstract logoutUser(federated: boolean): Promise<boolean | string>;
 }

--- a/src/auth0.android.ts
+++ b/src/auth0.android.ts
@@ -138,4 +138,20 @@ export class Auth0 extends Auth0Common {
             }
         });
     }
+    public logoutUser(federated: boolean): Promise<string> {
+        const auth = new WebAuthProvider(this.account);
+        return new Promise((resolve, reject) => {
+            try {
+                auth.clearSession(federated, (success) => {
+                    if (!success) {
+                        reject(new WebAuthException('Fail to Logout'));
+                    } else {
+                        resolve('Not Implemented Yet');
+                    }
+                });
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
 }

--- a/src/auth0.ios.ts
+++ b/src/auth0.ios.ts
@@ -141,4 +141,21 @@ export class Auth0 extends Auth0Common {
             }
         });
     }
+
+    public logoutUser(federated: boolean): Promise<boolean> {
+        const auth = SafariWebAuth.init(this.clientId, a0_url(this.domain));
+        return new Promise((resolve, reject) => {
+            try {
+               auth.clearSession(federated, (success) => {
+                   if (!success) {
+                       reject(new WebAuthException('Fail to Logout'));
+                   } else {
+                       resolve(success);
+                   }
+               });
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,4 +44,5 @@ export class Auth0 {
     public renewCredentials(refreshToken: string): Promise<Credentials>;
     public revokeRefreshToken(refreshToken: string): Promise<void>;
     public getUserInfo(accessToken: string): Promise<UserInfo>;
+    public logoutUser(federated: boolean): Promise<boolean | string>;
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

<!-- UNUSED FOR NOW
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue with the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included
-->

## What is the current behaviour?
No Logout is available to use, but the reset session in ios is available.
<!-- Please describe the current behaviour that you are modifying or linking to a relevant issue. -->

## What is the new behaviour?
Add in iOS a new function to log out the user.
<!-- Describe the changes. -->

Implements
Simply add the already available function clear session to a logout function. Android is not implemented yet because there is no clearSession functionality or at least I didn't find it
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

